### PR TITLE
Detect and set BinFolder when setting GamePath

### DIFF
--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
@@ -186,6 +186,7 @@ namespace GW2_Addon_Manager
                 if (value == _gamePath) return;
                 SetProperty(ref _gamePath, value);
                 _configurationManager.UserConfig.GamePath = value;
+                new Configuration(_configurationManager).DetermineSystemType();
                 _configurationManager.SaveConfiguration();
             }
         }


### PR DESCRIPTION
The BinFolder config item is detected at application launch, but not when
changing the GamePath. This can lead to an error if switching from a
32-bit client path to a 64-bit client path. In particular, this problem
arises on first launch if the game is not installed at the default path;
the launcher will always complain when changing the path until the config
is saved and reloaded.

This commit updates the "select directory" button to additionally redetect
and update the BinFolder value.